### PR TITLE
Bump @graphql-tools/load to v8.1.0

### DIFF
--- a/.changeset/shaggy-streets-see.md
+++ b/.changeset/shaggy-streets-see.md
@@ -1,0 +1,5 @@
+---
+'graphql-config': patch
+---
+
+Bump @graphql-tools/load to ^8.1.0 to support better error handling

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@graphql-tools/graphql-file-loader": "^8.0.0",
     "@graphql-tools/json-file-loader": "^8.0.0",
-    "@graphql-tools/load": "^8.0.0",
+    "@graphql-tools/load": "^8.1.0",
     "@graphql-tools/merge": "^9.0.0",
     "@graphql-tools/url-loader": "^8.0.0",
     "@graphql-tools/utils": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^8.0.0
         version: 8.0.18(graphql@16.10.0)
       '@graphql-tools/load':
-        specifier: ^8.0.0
-        version: 8.0.19(graphql@16.10.0)
+        specifier: ^8.1.0
+        version: 8.1.0(graphql@16.10.0)
       '@graphql-tools/merge':
         specifier: ^9.0.0
         version: 9.0.24(graphql@16.10.0)
@@ -456,8 +456,8 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
-  '@graphql-tools/load@8.0.19':
-    resolution: {integrity: sha512-YA3T9xTy2B6dNTnqsCzqSclA23j4v3p3A2Vdn0jEbZPGLMRPzWW8MJu2nlgQ8uua1IpYD/J8xgyrFxxAo3qPmQ==}
+  '@graphql-tools/load@8.1.0':
+    resolution: {integrity: sha512-OGfOm09VyXdNGJS/rLqZ6ztCiG2g6AMxhwtET8GZXTbnjptFc17GtKwJ3Jv5w7mjJ8dn0BHydvIuEKEUK4ciYw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -2603,7 +2603,7 @@ snapshots:
       tslib: 2.8.1
       unixify: 1.0.0
 
-  '@graphql-tools/load@8.0.19(graphql@16.10.0)':
+  '@graphql-tools/load@8.1.0(graphql@16.10.0)':
     dependencies:
       '@graphql-tools/schema': 10.0.23(graphql@16.10.0)
       '@graphql-tools/utils': 10.8.6(graphql@16.10.0)


### PR DESCRIPTION
## Description

This PR bumps `@graphql-tools/load` to `^8.1.0`

`@graphql-tools/load@8.1.0` is released after this [PR](https://github.com/ardatan/graphql-tools/pull/7093) with an improvement to error handling.

Whilst integrating with https://github.com/dotansimha/graphql-code-generator/pull/10338 to fix error handling, I noticed existing consumers _may_ get into a state where `graphql-config` brings `@graphql-tools/load` lower than 8.1.0, but the codepath that uses `@graphql-tools/load` directly brings in 8.1.0. This causes inconsistency with error message.

We technically don't have to do this in `graphql-config`, however, this change ensures both code paths work the same way without consumers having to do anything.


## Type of change

- [x] Version bump
