### PR TITLE
Revert major package versions

### DIFF
--- a/.changeset/brave-knives-remain.md
+++ b/.changeset/brave-knives-remain.md
@@ -1,0 +1,5 @@
+---
+'graphql-config': patch
+---
+
+Revert minimatch and cosmiconfig versions

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@graphql-tools/utils": "^10.0.0",
     "cosmiconfig": "^8.1.0",
     "jiti": "^2.0.0",
-    "minimatch": "^10.0.0",
+    "minimatch": "^9.0.5",
     "string-env-interpolation": "^1.0.1",
     "tslib": "^2.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@graphql-tools/merge": "^9.0.0",
     "@graphql-tools/url-loader": "^8.0.0",
     "@graphql-tools/utils": "^10.0.0",
-    "cosmiconfig": "^9.0.0",
+    "cosmiconfig": "^8.1.0",
     "jiti": "^2.0.0",
     "minimatch": "^10.0.0",
     "string-env-interpolation": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^2.0.0
         version: 2.4.2
       minimatch:
-        specifier: ^10.0.0
-        version: 10.0.1
+        specifier: ^9.0.5
+        version: 9.0.5
       string-env-interpolation:
         specifier: ^1.0.1
         version: 1.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^10.0.0
         version: 10.8.6(graphql@16.10.0)
       cosmiconfig:
-        specifier: ^9.0.0
-        version: 9.0.0(typescript@5.8.2)
+        specifier: ^8.1.0
+        version: 8.3.6(typescript@5.8.2)
       jiti:
         specifier: ^2.0.0
         version: 2.4.2
@@ -938,8 +938,8 @@ packages:
   cosmiconfig-toml-loader@1.0.0:
     resolution: {integrity: sha512-H/2gurFWVi7xXvCyvsWRLCMekl4tITJcX0QEsDMpzxtuxDyM59xLatYNg4s/k9AA/HdtCYfj2su8mgA0GSDLDA==}
 
-  cosmiconfig@9.0.0:
-    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
+  cosmiconfig@8.3.6:
+    resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
     peerDependencies:
       typescript: '>=4.9.5'
@@ -1023,10 +1023,6 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
-
-  env-paths@2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
-    engines: {node: '>=6'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -3100,12 +3096,12 @@ snapshots:
     dependencies:
       '@iarna/toml': 2.2.5
 
-  cosmiconfig@9.0.0(typescript@5.8.2):
+  cosmiconfig@8.3.6(typescript@5.8.2):
     dependencies:
-      env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.0
       parse-json: 5.2.0
+      path-type: 4.0.0
     optionalDependencies:
       typescript: 5.8.2
 
@@ -3168,8 +3164,6 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
-
-  env-paths@2.2.1: {}
 
   environment@1.1.0: {}
 


### PR DESCRIPTION
## Description

[v5.1.4](https://github.com/graphql-hive/graphql-config/releases/tag/v5.1.4) was released with 2 major version updates for some dependencies, which break consumers:

- `minimatch` 9.0.5 -> v10.0.0: this drops support for Node 16 and 18, which breaks Codegen support.
- `cosmiconfig`  8.1.0 -> v9.0.0: this causes issues in integration: https://github.com/graphql-hive/graphql-config/issues/1726

For now, this PR reverts these two version bumps to unblock consumers.
Next, we'd need to have tests to catch these failing integrations.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
