### PR TITLE
Ignore cosmiconfig, minimatch in Renovate to avoid accidental reverts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "ignoreDeps": ["cosmiconfig", "minimatch"]
+}


### PR DESCRIPTION
## Description

We bumped `minimatch` and `cosmiconfig` major versions, and caused an issue:  https://github.com/graphql-hive/graphql-config/issues/1726

This is not the first time either, we had to revert 5.1.2 for similar reasons: https://github.com/graphql-hive/graphql-config/pull/1572.

This PR adds `minimatch` and `cosmiconfig` to Renovate ignore list, so we don't accidentally do the same thing. 