### PR TITLE
Revert "add graphql conf 2024 banner (#1483)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-[![GraphQLConf 2024 Banner: September 10-12, San Francisco. Hosted by the GraphQL Foundation](https://github.com/user-attachments/assets/bdb8cd5d-5186-4ece-b06b-b00a499b7868)](https://graphql.org/conf/2024/?utm_source=github&utm_medium=graphql_config&utm_campaign=readme)
-
-<!-- Uncomment when we remove GraphQL Conf banner -->
-<!-- ![GraphQL Config](https://i.imgur.com/hw5tXw2.gif 'GraphQL Config') -->
+![GraphQL Config](https://i.imgur.com/hw5tXw2.gif 'GraphQL Config')
 
 [![npm version](https://badge.fury.io/js/graphql-config.svg)](https://npmjs.com/package/graphql-config)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)


### PR DESCRIPTION

## Description

Remove the GraphQL 2024 banner since this event has already ended. This is done by reverting commit 82aa95e4e6a5fe46dcb2d9b012bef83f05814902 / Pull Request https://github.com/graphql-hive/graphql-config/pull/1483

## Type of change

README.md Update.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
